### PR TITLE
Add Python 3.4 back, now that PyEnsembl works

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ sudo: false  # Use container-based infrastructure
 language: python
 python:
   - "2.7"
+  - "3.4"
 addons:
   apt:
     packages:


### PR DESCRIPTION
Now that PyEnsembl runs on Travis, the 3.4 run for topiary should work.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/topiary/30)
<!-- Reviewable:end -->
