### PR TITLE
Improve RNA loading

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,10 +27,11 @@ before_install:
   - export NETMHC_BUNDLE_TMPDIR=$PWD/tmp
   - export PATH=$PATH:$NETMHC_BUNDLE_HOME/bin
 install:
-  - conda install --yes python=$TRAVIS_PYTHON_VERSION numpy scipy nose pandas matplotlib pypandoc
+  - conda install --yes python=$TRAVIS_PYTHON_VERSION numpy scipy nose pandas matplotlib
   - pip install -r requirements.txt
   - pip install .
   - pip install coveralls
+  - pip install pypandoc
   - pyensembl install --release 75 --species human
   - pyensembl install --release 81 --species human
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,9 @@ addons:
   apt:
     packages:
       # Needed for NetMHC
-      tcsh
+      - tcsh
+      # add pandoc to properly generate README as reStructuredText
+      - pandoc
 env:
   global:
     # MHC_BUNDLE_PASS

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_install:
   - export NETMHC_BUNDLE_TMPDIR=$PWD/tmp
   - export PATH=$PATH:$NETMHC_BUNDLE_HOME/bin
 install:
-  - conda install --yes python=$TRAVIS_PYTHON_VERSION numpy scipy nose pandas matplotlib
+  - conda install --yes python=$TRAVIS_PYTHON_VERSION numpy scipy nose pandas matplotlib pypandoc
   - pip install -r requirements.txt
   - pip install .
   - pip install coveralls

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ except:
 if __name__ == '__main__':
     setup(
         name='topiary',
-        version="0.0.13",
+        version="0.0.14",
         description="Predict cancer epitopes from cancer sequence data",
         author="Alex Rubinsteyn, Tavi Nathanson",
         author_email="alex {dot} rubinsteyn {at} gmail {dot} com",

--- a/test/test_epitopes_from_commandline_args.py
+++ b/test/test_epitopes_from_commandline_args.py
@@ -5,6 +5,7 @@ from topiary.commandline_args import arg_parser
 
 from .data import cancer_test_variants
 
+
 def test_cancer_epitopes_from_args():
     epitope_lengths = [9, 10]
     alleles = ["HLA-A*02:01", "C0701"]

--- a/test/test_rna_helpers.py
+++ b/test/test_rna_helpers.py
@@ -1,0 +1,29 @@
+import pandas as pd
+from topiary.rna.cufflinks import parse_locus_column
+from nose.tools import eq_
+
+
+def test_parse_locus_column_with_chr():
+    """
+    test_parse_locus_column_with_chr: Test that 'chr' prefix from
+    chromosome names gets correctly dropped
+    """
+    df = pd.DataFrame({"locus": ["chr1:10-20", "chrX:30-40"]})
+    loci = df["locus"]
+    chromosomes, starts, ends = parse_locus_column(loci)
+    eq_(list(chromosomes), ["1", "X"])
+    eq_(list(starts), [10, 30])
+    eq_(list(ends), [20, 40])
+
+
+def test_parse_locus_column_without_chr():
+    """
+    test_parse_locus_column_without_chr: Test that chromosome names can be
+    parsed without 'chr' prefix
+    """
+    df = pd.DataFrame({"locus": ["1:10-20", "X:30-40"]})
+    loci = df["locus"]
+    chromosomes, starts, ends = parse_locus_column(loci)
+    eq_(list(chromosomes), ["1", "X"])
+    eq_(list(starts), [10, 30])
+    eq_(list(ends), [20, 40])

--- a/topiary/rna/common.py
+++ b/topiary/rna/common.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2015. Mount Sinai School of Medicine
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def infer_separator(filename):
+    """
+    Given a file which contains data separated by one of the following:
+        - commas
+        - tabs
+        - spaces
+    Return the most likely separator by sniffing the first 1000 bytes
+    of the file's contents.
+    """
+    with open(filename, "r") as f:
+        # read first thousand bytes of the file which should contain at
+        # least one instance of the field separator
+        substring = f.read(1000)
+        comma_counts = substring.count(",")
+        tab_counts = substring.count("\t")
+        if comma_counts > tab_counts:
+            return ","
+        elif tab_counts > 0:
+            return "\t"
+        elif " " in substring:
+            return "\s+"
+        else:
+            raise ValueError(
+                "Unable to infer field separator for %s" % filename)
+
+
+def check_required_columns(df, filename, required_columns):
+    """
+    Ensure that all required columns are present in the given dataframe,
+    otherwise raise an exception.
+    """
+    available_columns = set(df.columns)
+    for column_name in required_columns:
+        if column_name not in available_columns:
+            raise ValueError("FPKM tracking file %s missing column '%s'" % (
+                filename,
+                column_name))

--- a/topiary/rna/common.py
+++ b/topiary/rna/common.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import re
+
 
 def infer_delimiter(filename, comment_char="#", n_lines=3):
     """
@@ -34,17 +36,12 @@ def infer_delimiter(filename, comment_char="#", n_lines=3):
     if len(lines) < n_lines:
         raise ValueError(
             "Not enough lines in %s to infer delimiter" % filename)
-    # the split function defaults to splitting on multiple spaces,
-    # which here corresponds to a candidate value of None
-    candidate_delimiters = ["\t", ",", None]
+    candidate_delimiters = ["\t", ",", "\s+"]
     for candidate_delimiter in candidate_delimiters:
-        counts = [len(line.split(candidate_delimiter)) for line in lines]
+        counts = [len(re.split(candidate_delimiter, line)) for line in lines]
         first_line_count = counts[0]
         if all(c == first_line_count for c in counts) and first_line_count > 1:
-            if candidate_delimiter is None:
-                return "\s+"
-            else:
-                return candidate_delimiter
+            return candidate_delimiter
     raise ValueError("Could not determine delimiter for %s" % filename)
 
 

--- a/topiary/rna/cufflinks.py
+++ b/topiary/rna/cufflinks.py
@@ -19,11 +19,11 @@ import logging
 import pandas as pd
 import numpy as np
 
-from .common import infer_separator, check_required_columns
+from .common import infer_delimiter, check_required_columns
 
 
 def parse_locus_column(loci):
-    # capture all characters after 'chr' but before ':'
+    # capture all characters before ':' (drop 'chr' if present)
     chromosomes = loci.str.extract("(?:chr)?([^:]*):.*")
     # capture all characters after e.g. 'chr1:', which look like '132-394'
     ranges = loci.str.extract("(?:chr)?[^:]*:(.*)")
@@ -120,9 +120,9 @@ def load_cufflinks_dataframe(
         gene_names : str list
     """
     if sep is None:
-        sep = infer_separator(filename)
+        sep = infer_delimiter(filename)
 
-    df = pd.read_csv(filename, sep=sep)
+    df = pd.read_csv(filename, sep=sep, engine="c")
 
     required_columns = {
         status_column,

--- a/topiary/rna/cufflinks.py
+++ b/topiary/rna/cufflinks.py
@@ -198,11 +198,10 @@ def load_cufflinks_dataframe(
             known = np.ones(len(df), dtype='bool')
 
     loci = df[locus_column]
-
     # capture all characters after 'chr' but before ':'
     chromosomes = loci.str.extract("chr([^:]*):.*")
     # capture all characters after e.g. 'chr1:', which look like '132-394'
-    ranges = loci.str.extract("chr[^:]*:(.*)")
+    ranges = loci.str.extract("(?:chr)?[^:]*:(.*)")
     # capture all numbers before the dash
     starts = ranges.str.extract("(\d*)-\d*").astype(int)
     # capture all numbers after the dash

--- a/topiary/rna/cufflinks.py
+++ b/topiary/rna/cufflinks.py
@@ -35,7 +35,7 @@ def _infer_separator(filename):
         substring = f.read(1000)
         comma_counts = substring.count(",")
         tab_counts = substring.count("\t")
-        if comma_counts > 0 and comma_counts > tab_counts:
+        if comma_counts > tab_counts:
             return ","
         elif tab_counts > 0:
             return "\t"


### PR DESCRIPTION
Currently the loading/filtering code makes some restrictive assumptions that cause Topiary to fail for some "in the wild" FPKM tracking files. 

- infer separator for CSV vs. TSV files 
- don't assume that loci start with "chr"

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/topiary/38)
<!-- Reviewable:end -->
