### PR TITLE
Import normalize_allele_name from mhcnames instead mhctools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,7 @@ install:
   - pyensembl install --release 75 --species human
   - pyensembl install --release 84 --species human
   - pyensembl install --release 85 --species human
+  - pyensembl install --release 87 --species human
 
 script:
   - nosetests test --with-coverage --cover-package=topiary && ./lint.sh

--- a/topiary/__init__.py
+++ b/topiary/__init__.py
@@ -21,7 +21,7 @@ from .sequence_helpers import (
 )
 from . import commandline_args
 
-__version__ = '0.1.0'
+__version__ = '0.1.1'
 
 __all__ = [
     "LazyLigandomeDict",

--- a/topiary/lazy_ligandome_dict.py
+++ b/topiary/lazy_ligandome_dict.py
@@ -14,7 +14,7 @@
 
 from os import listdir
 from os.path import join
-from mhctools import normalize_allele_name
+from mhcnames import normalize_allele_name
 
 class AlleleNotFound(Exception):
     pass


### PR DESCRIPTION
Otherwise a clean pip installs `topiary v0.1.0` and also its dependency `mhctools v0.5.0` that doesn't have `normalize_allele_name` anymore. And topiary fails as follows:

```
$ topiary --help
Traceback (most recent call last):
  File "/Users/arman/miniconda2/envs/topiary/bin/topiary", line 33, in <module>
    from topiary.commandline_args import (
  File "/Users/arman/miniconda2/envs/topiary/lib/python3.6/site-packages/topiary/__init__.py", line 2, in <module>
    from .lazy_ligandome_dict import LazyLigandomeDict, AlleleNotFound
  File "/Users/arman/miniconda2/envs/topiary/lib/python3.6/site-packages/topiary/lazy_ligandome_dict.py", line 17, in <module>
    from mhctools import normalize_allele_name
ImportError: cannot import name 'normalize_allele_name'
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/topiary/67)
<!-- Reviewable:end -->
